### PR TITLE
Simplify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use the following code in your app to retrieve the config:
 ```js
 const namespace = "/mydomain/myapp";
 const config = await getConfig(namespace);
-setAppName(config.name) // Do whatever you need to do with config.name here
+setAppName(config["/name"]);
 ```
 
 TODO: Example of what IAM permissions the function needs in order to run.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,3 @@ terraform init acceptance/infra
 terraform apply acceptance/infra
 npm run test:acceptance
 ```
-
-## FAQ
-
-### Why do I need to add a leading / trailing slash on my namespace?
-
-TODO: chat about the implications for IAM Permissions
-TODO: should we reconsider this? Perhaps you could just supply the namespace as foo.bar or something like that?

--- a/acceptance/dotssm.spec.ts
+++ b/acceptance/dotssm.spec.ts
@@ -10,13 +10,11 @@ describe("Given there are two SSM parameters prefixed with /foo", () => {
   describe("And there is no .ssm file in the current working directory", () => {
     describe("When I call getConfig with the foo namespace", () => {
       it("Then I successfully retrieve the two config values from SSM", async () => {
-        const result = await getConfig("/foo/");
+        const result = await getConfig("/foo");
         expect(result).toEqual({
-          bar: "bar",
-          secret: "somethingsecret",
-          nested: {
-            value: "this config is nested"
-          }
+          "/bar": "bar",
+          "/secret": "somethingsecret",
+          "/nested/value": "this config is nested"
         });
       });
     });
@@ -26,11 +24,11 @@ describe("Given there are two SSM parameters prefixed with /foo", () => {
     describe("When I call getConfig with the foo namespace", () => {
       it("Then I successfully retrieve the two config values from SSM", async () => {
         process.chdir(path.join(fixturesDirectory, "complex"));
-        const result = await getConfig("/foo/");
+        const result = await getConfig("/foo");
         expect(result).toEqual({
-          bar: "baz",
-          secret: "localsecret",
-          nested: { value: "this config is nested" }
+          "/bar": "baz",
+          "/secret": "localsecret",
+          "/nested/value": "this config is nested"
         });
       });
     });

--- a/lib/fallback.spec.ts
+++ b/lib/fallback.spec.ts
@@ -1,7 +1,7 @@
 import { Config } from "./types";
 import { fallback } from "./fallback";
 
-const anyNamespace = "some/namespace";
+const anyNamespace = "/some/namespace";
 
 describe("Given there is a config func and fallback", () => {
   describe("When the first config func returns a valid config", () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,7 +5,7 @@ import { ssm } from "./ssm";
 
 /**
  * Used to retrieve config from either a local file or parameter store.
- * Returns `undefined` if there are no values found in the given namespace.
+ * Returns an empty config if there are no values found in the given namespace.
  * Searches for the local file at `.ssm.json` in the current working directory.
  *
  * @param namespace The SSM namespace to search for the application config

--- a/lib/local.spec.ts
+++ b/lib/local.spec.ts
@@ -9,8 +9,7 @@ const multipleFixturesDir = path.join(fixturesDir, "multiple-keys");
 const nestedFixturesDir = path.join(fixturesDir, "nested");
 
 const validNamespace = "/foo/bar";
-const unknownNamespace = "/invalid/namespace/";
-const invalidNamespace = "/foo/bar/";
+const unknownNamespace = "/unknown/namespace/";
 const anyNamespace = "/some/namespace";
 
 describe("Given there is a .ssm file in the current working directory", () => {
@@ -35,6 +34,7 @@ describe("Given there is a .ssm file in the current working directory", () => {
   describe("When getConfig is called with an invalid namespace", () => {
     it("Then it returns an empty object", async () => {
       process.chdir(nestedFixturesDir);
+      const invalidNamespace = validNamespace + "/";
       const result = await getConfig(invalidNamespace);
       expect(result).toEqual({});
     });

--- a/lib/local.spec.ts
+++ b/lib/local.spec.ts
@@ -8,9 +8,10 @@ const customFixturesDir = path.join(fixturesDir, "custom");
 const multipleFixturesDir = path.join(fixturesDir, "multiple-keys");
 const nestedFixturesDir = path.join(fixturesDir, "nested");
 
-const validNamespace = "/foo/bar/";
-const invalidNamespace = "/invalid/namespace/";
-const anyNamespace = "/some/namespace/";
+const validNamespace = "/foo/bar";
+const unknownNamespace = "/invalid/namespace/";
+const invalidNamespace = "/foo/bar/";
+const anyNamespace = "/some/namespace";
 
 describe("Given there is a .ssm file in the current working directory", () => {
   describe("When getConfig is called with the correct namespace", () => {
@@ -18,8 +19,16 @@ describe("Given there is a .ssm file in the current working directory", () => {
       process.chdir(nestedFixturesDir);
       const result = await getConfig(validNamespace);
       expect(result).toEqual({
-        greeting: "Hello, world"
+        "/greeting": "Hello, world"
       });
+    });
+  });
+
+  describe("When getConfig is called with an unknown namespace", () => {
+    it("Then it returns an empty object", async () => {
+      process.chdir(nestedFixturesDir);
+      const result = await getConfig(unknownNamespace);
+      expect(result).toEqual({});
     });
   });
 
@@ -27,7 +36,7 @@ describe("Given there is a .ssm file in the current working directory", () => {
     it("Then it returns an empty object", async () => {
       process.chdir(nestedFixturesDir);
       const result = await getConfig(invalidNamespace);
-      expect(result).toEqual(undefined);
+      expect(result).toEqual({});
     });
   });
 
@@ -35,10 +44,10 @@ describe("Given there is a .ssm file in the current working directory", () => {
     describe("When getConfig is called with the correct namespace", () => {
       it("Then it returns all the matching keys", async () => {
         process.chdir(multipleFixturesDir);
-        const result = await getConfig("/foo/");
+        const result = await getConfig("/foo");
         expect(result).toEqual({
-          bar: "baz",
-          secret: "localsecret"
+          "/bar": "baz",
+          "/secret": "localsecret"
         });
       });
     });
@@ -48,11 +57,9 @@ describe("Given there is a .ssm file in the current working directory", () => {
     describe("When getConfig is called with the correct namespace", () => {
       it("Then it returns nested config as an object", async () => {
         process.chdir(nestedFixturesDir);
-        const result = await getConfig("/foo/");
+        const result = await getConfig("/foo");
         expect(result).toEqual({
-          bar: {
-            greeting: "Hello, world"
-          }
+          "/bar/greeting": "Hello, world"
         });
       });
     });
@@ -74,9 +81,9 @@ describe("Given there is a config.json file present", () => {
     const getConfig = local("config.json");
     it("Then it returns the config object", async () => {
       process.chdir(customFixturesDir);
-      const result = await getConfig("/foo/");
+      const result = await getConfig("/foo");
       expect(result).toEqual({
-        bar: "baz"
+        "/bar": "baz"
       });
     });
   });

--- a/lib/ssm.ts
+++ b/lib/ssm.ts
@@ -1,48 +1,25 @@
 import AWS from "aws-sdk";
-import { GetConfigFunc } from "./types";
+import { GetConfigFunc, Config } from "./types";
 
 export const ssm = (
   client: AWS.SSM = new AWS.SSM()
 ): GetConfigFunc => async namespace => {
   const params: AWS.SSM.GetParametersByPathRequest = {
-    Path: namespace,
+    Path: namespace + "/",
     Recursive: true,
     WithDecryption: true
     // TODO: Handle pagination
   };
   const res = await client.getParametersByPath(params).promise();
-  const result = {};
+  const result: Config = {};
 
-  // TODO: How do we handle two keys that conflict with one another?
-  // eg. /foo/bar/config and /foo/bar
-  // That can't be represented in the format that config is currently returned in
-  // It probably should result in an error.
   res.Parameters?.forEach(p => {
     if (!p.Name || !p.Value) {
       return;
     }
     const name = p.Name.substr(namespace.length);
-    const parts = name.split("/").filter(v => v.length > 0);
-    set(result, parts, p.Value);
+    result[name] = p.Value;
   });
 
   return result;
-};
-
-const set = (target: any, path: string[], value: string) => {
-  if (path.length === 0) {
-    return;
-  }
-
-  if (path.length === 1) {
-    const key = path[0];
-    return (target[key] = value);
-  }
-
-  const inner = {};
-  const key = path.shift();
-  if (key) {
-    target[key] = inner;
-    set(inner, path, value);
-  }
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
-export const NO_CONFIG = {};
+export type Config = Record<string, string | undefined>; // TODO: Support string list type?
 
-export type Config = { [key: string]: string | Config }; // TODO: Support string list type?
+export const NO_CONFIG: Config = {};
 
 export type GetConfigFunc = (namespace: string) => Promise<Config>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "target": "es5"
   },
   "include": ["lib"],
-  "exclude": ["node_modules", "acceptance", "*.spec.ts"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Making slashes more consistent and avoiding the edge case where two parameters may share an object path (eg. `foo` and `foo/bar` - can't be represented in JSON).